### PR TITLE
unrefing timeout to not hang on stop

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,6 +150,10 @@ Client.prototype._requestUdp = function (announceUrl, opts) {
     error('tracker request timed out')
   }, 15000)
 
+  if (timeout.unref) {
+    timeout.unref()
+  }
+
   function error (message) {
     self.emit('error', new Error(message))
     socket.close()


### PR DESCRIPTION
Currently `client.stop()` can make the program hang since the udp request have triggered a `setTimeout`. This PR fixes this by calling `unref` on the timeout to not have the program hang (useful in testing)
