### PR TITLE
Fix for unknown port

### DIFF
--- a/index.js
+++ b/index.js
@@ -208,6 +208,9 @@ Client.prototype._requestUdp = function (announceUrl, opts) {
   })
 
   function send (message) {
+    if(parsedUrl.port==null) {
+      parsedUrl.port=80;
+    }
     socket.send(message, 0, message.length, parsedUrl.port, parsedUrl.hostname)
   }
 


### PR DESCRIPTION
For example, in torrents from Yify their tracker has url "udp://tracker.yify-torrents.com/announce" in which case a crtitical error is shown because "port should be in range from 0 to 65535"
