### PR TITLE
use bn.js instead of bignum

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,7 @@
 exports.Client = Client
 exports.Server = Server
 
-// optional compiled dependency. if it doesn't compile, no big deal.
-var bignum
-try {
-  bignum = require('bignum')
-} catch (e) {}
-
+var bn = require('bn.js')
 var bncode = require('bncode')
 var compact2string = require('compact2string')
 var dgram = require('dgram')
@@ -528,16 +523,12 @@ function toUInt32 (n) {
 }
 
 function toUInt64 (n) {
-  if (typeof bignum === 'function') {
-    return bignum(n).toBuffer({ size: 8 })
-  } else {
-    // optional compiled dependency 'bignum' is not available, so round down to MAX_UINT.
-    // These values are only used for tracker stats anyway.
-    if (n > MAX_UINT) {
-      n = MAX_UINT
-    }
-    return Buffer.concat([toUInt32(0), toUInt32(n)])
+  if (n > MAX_UINT || typeof n === 'string') {
+    var bytes = bn(n).toArray()
+    while (bytes.length < 8) bytes.unshift(0)
+    return new Buffer(bytes)
   }
+  return Buffer.concat([toUInt32(0), toUInt32(n)])
 }
 
 function bytewiseEncodeURIComponent (buf) {

--- a/package.json
+++ b/package.json
@@ -18,15 +18,13 @@
     "inherits": "^2.0.1",
     "querystring": "^0.2.0",
     "run-parallel": "^0.3.0",
-    "string2compact": "^1.1.0"
+    "string2compact": "^1.1.0",
+    "bn.js": "^0.2.0"
   },
   "devDependencies": {
     "parse-torrent": "^0.9.0",
     "portfinder": "^0.2.1",
     "tape": "2.x"
-  },
-  "optionalDependencies": {
-    "bignum": "^0.6.2"
   },
   "homepage": "http://webtorrent.io",
   "keywords": [


### PR DESCRIPTION
Like we discussed I would like to not use the native module bignum since it gives major headaches to people using windows.

This PR swaps out bignum for bn.js which is written in js.
