### PR TITLE
Separate Trackers and support scrape messages

### DIFF
--- a/test/server.js
+++ b/test/server.js
@@ -11,7 +11,7 @@ var peerId = '12345678901234567890'
 var torrentLength = 50000
 
 test('server', function (t) {
-  t.plan(17)
+  t.plan(21)
 
   var server = new Server() // { interval: 50000, compactOnly: false }
 
@@ -66,14 +66,22 @@ test('server', function (t) {
         t.equal(data.complete, 1)
         t.equal(data.incomplete, 0)
 
-        client.stop()
-
-        client.once('update', function (data) {
+        client.scrape()
+        client.once('scrape', function (data) {
           t.equal(data.announce, announceUrl)
-          t.equal(data.complete, 0)
-          t.equal(data.incomplete, 0)
+          t.equal(typeof data.complete, 'number')
+          t.equal(typeof data.incomplete, 'number')
+          t.equal(typeof data.downloaded, 'number')
 
-          server.close()
+          client.once('update', function (data) {
+            t.equal(data.announce, announceUrl)
+            t.equal(data.complete, 0)
+            t.equal(data.incomplete, 0)
+
+            server.close()
+          })
+          
+          client.stop()
         })
       })
     })

--- a/test/udp-client.js
+++ b/test/udp-client.js
@@ -7,7 +7,8 @@ var torrent = fs.readFileSync(__dirname + '/torrents/leaves.torrent')
 var parsedTorrent = parseTorrent(torrent)
 
 // remove all tracker servers except a single UDP one, for now
-parsedTorrent.announce = [ 'udp://tracker.publicbt.com:80' ]
+var announceUrl = 'udp://tracker.publicbt.com:80'
+parsedTorrent.announce = [ announceUrl ]
 
 var peerId = new Buffer('01234567890123456789')
 var port = 6881
@@ -22,7 +23,7 @@ test('udp: client.start/update/stop()', function (t) {
   })
 
   client.once('update', function (data) {
-    t.equal(data.announce, 'udp://tracker.publicbt.com:80')
+    t.equal(data.announce, announceUrl)
     t.equal(typeof data.complete, 'number')
     t.equal(typeof data.incomplete, 'number')
   })
@@ -32,17 +33,17 @@ test('udp: client.start/update/stop()', function (t) {
 
     client.once('update', function (data) {
       // receive one final update after calling stop
-      t.equal(data.announce, 'udp://tracker.publicbt.com:80')
+      t.equal(data.announce, announceUrl)
       t.equal(typeof data.complete, 'number')
       t.equal(typeof data.incomplete, 'number')
 
       client.once('update', function (data) {
         // received an update!
-        t.equal(data.announce, 'udp://tracker.publicbt.com:80')
+        t.equal(data.announce, announceUrl)
         t.equal(typeof data.complete, 'number')
         t.equal(typeof data.incomplete, 'number')
       })
-
+      
       client.stop()
     })
 


### PR DESCRIPTION
2 commits:
1. Refactor to support trackerId and announce interval per Tracker instead of per Client.  This makes Client a pretty simple collection proxy of Trackers.
2. Add client and server support for scrape messages (in addition to the traditional announce message); client http/udp and server http support are included.
