### PR TITLE
tracker mangles peer ports

### DIFF
--- a/test/server.js
+++ b/test/server.js
@@ -11,7 +11,7 @@ var peerId = '12345678901234567890'
 var torrentLength = 50000
 
 test('server', function (t) {
-  t.plan(22)
+  t.plan(23)
 
   var server = new Server() // { interval: 50000, compactOnly: false }
 
@@ -82,6 +82,7 @@ test('server', function (t) {
 
           client2.once('peer', function (addr) {
             t.equal(addr, '127.0.0.1:6881')
+            client2.stop()
             client.stop()
 
             client.once('update', function (data) {


### PR DESCRIPTION
The tracker seems to mangle port information when returning peers in compact (binary) model. This PR illustrates the problem via a failing test:

```
    expected: '127.0.0.1:6881'
    actual:   '127.0.0.1:6895'
```

Two peers connect to the tracker: one on port 6881 and another on 6882. When receiving a response from the tracker the second peer expects to find the first one, but instead discovers an erroneous peer.

Consequently, when returning peers in non-compact (dictionary) model, the tracker seems to mangle IP information, but that's a separate issue.
