### PR TITLE
only handle response if there is any data

### DIFF
--- a/index.js
+++ b/index.js
@@ -153,7 +153,7 @@ Tracker.prototype._requestHttp = function (requestUrl, opts) {
       return
     }
     res.pipe(concat(function (data) {
-      self._handleResponse(requestUrl, data)
+      if (data && data.length) self._handleResponse(requestUrl, data)
     }))
   })
 


### PR DESCRIPTION
This fixes an edge case I just ran into. Basically some trackers returns empty data but still a 200 response which makes bittorrent-tracker crash.

This fixes this.

(a quick merge + release would be appreciated since I wanna use this in a demo tomorrow)
