### PR TITLE
client _handleResponse: allow string form of peer.ip

### DIFF
--- a/client.js
+++ b/client.js
@@ -497,8 +497,10 @@ Tracker.prototype._handleResponse = function (requestUrl, data) {
       // tracker returned normal response
       data.peers.forEach(function (peer) {
         var ip = peer.ip
-        var addr = ip[0] + '.' + ip[1] + '.' + ip[2] + '.' + ip[3] + ':' + peer.port
-        self.client.emit('peer', addr)
+        var host = ip.length == 4 ?
+          (ip[0] + '.' + ip[1] + '.' + ip[2] + '.' + ip[3]) :
+          ip.toString()
+        self.client.emit('peer', host + ':' + peer.port)
       })
     }
   } else if (requestUrl === self._scrapeUrl) {


### PR DESCRIPTION
[BEP-3](http://bittorrent.org/beps/bep_0003.html) states:

> peers maps to a list of dictionaries corresponding to peers, each of which contains the keys peer id, ip, and port, which map to the peer's self-selected ID, **IP address or dns name as a string**, and port number, respectively.

The [Theory.org Wiki](https://wiki.theory.org/BitTorrentSpecification#Tracker_Response) agrees.

Is there any evidence of binary ip fields in the wild? Anyway, this code should support both.
