### PR TITLE
Allow proxy usage on tracker clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,26 +73,43 @@ var optionalOpts = {
       customParam: 'blah' // custom parameters supported
     }
   },
-  // NodeJS HTTP agent implementation (used to proxy HTTP and Websocket requests in node)
-  httpAgent: {},
-  // Socks proxy options (used to proxy UDP requests in node)
-  socksProxyOpts: {
-      // Configuration from socks module (https://github.com/JoshGlazebrook/socks)
-      proxy: {
-          // IP Address of Proxy (Required)
-          ipaddress: "1.2.3.4",
-          // TCP Port of Proxy (Required)
-          port: 1080,
-          // Proxy Type 5 (Required)
-          // Type 4 does not support UDP association relay 
-          type: 5,
   
-          // Authentication used for SOCKS 5 (when it's required) (Optional)
-          authentication: {
-              username: "Josh",
-              password: "somepassword"
-          }
-      }
+  proxyOpts: {
+      // Socks proxy options (used to proxy requests in node)
+      socksProxyOpts: {
+          // Configuration from socks module (https://github.com/JoshGlazebrook/socks)
+          proxy: {
+              // IP Address of Proxy (Required)
+              ipaddress: "1.2.3.4",
+              // TCP Port of Proxy (Required)
+              port: 1080,
+              // Proxy Type [4, 5] (Required)
+              // Note: 4 works for both 4 and 4a.
+              // Type 4 does not support UDP association relay 
+              type: 5,
+              
+              // SOCKS 4 Specific:
+              
+              // UserId used when making a SOCKS 4/4a request. (Optional)
+              userid: "someuserid",
+
+              // SOCKS 5 Specific:
+      
+              // Authentication used for SOCKS 5 (when it's required) (Optional)
+              authentication: {
+                  username: "Josh",
+                  password: "somepassword"
+              }
+          },
+          
+          // Amount of time to wait for a connection to be established. (Optional)
+          // - defaults to 10000ms (10 seconds)
+          timeout: 10000
+      },
+      // NodeJS HTTP agents (used to proxy HTTP and Websocket requests in node)
+      // Populated with Socks.Agent if socksProxyOpts is provided
+      httpAgent: {},
+      httpsAgent: {}
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ var optionalOpts = {
   
   proxyOpts: {
       // Socks proxy options (used to proxy requests in node)
-      socksProxyOpts: {
+      socksProxy: {
           // Configuration from socks module (https://github.com/JoshGlazebrook/socks)
           proxy: {
               // IP Address of Proxy (Required)
@@ -107,7 +107,7 @@ var optionalOpts = {
           timeout: 10000
       },
       // NodeJS HTTP agents (used to proxy HTTP and Websocket requests in node)
-      // Populated with Socks.Agent if socksProxyOpts is provided
+      // Populated with Socks.Agent if socksProxy is provided
       httpAgent: {},
       httpsAgent: {}
   }

--- a/README.md
+++ b/README.md
@@ -72,6 +72,27 @@ var optionalOpts = {
       left: 0,
       customParam: 'blah' // custom parameters supported
     }
+  },
+  // NodeJS HTTP agent implementation (used to proxy HTTP and Websocket requests in node)
+  httpAgent: {},
+  // Socks proxy options (used to proxy UDP requests in node)
+  socksProxyOpts: {
+      // Configuration from socks module (https://github.com/JoshGlazebrook/socks)
+      proxy: {
+          // IP Address of Proxy (Required)
+          ipaddress: "1.2.3.4",
+          // TCP Port of Proxy (Required)
+          port: 1080,
+          // Proxy Type 5 (Required)
+          // Type 4 does not support UDP association relay 
+          type: 5,
+  
+          // Authentication used for SOCKS 5 (when it's required) (Optional)
+          authentication: {
+              username: "Josh",
+              password: "somepassword"
+          }
+      }
   }
 }
 

--- a/client.js
+++ b/client.js
@@ -8,7 +8,6 @@ var inherits = require('inherits')
 var once = require('once')
 var parallel = require('run-parallel')
 var Peer = require('simple-peer')
-var Socks = require('socks')
 var uniq = require('uniq')
 var url = require('url')
 

--- a/client.js
+++ b/client.js
@@ -32,6 +32,7 @@ inherits(Client, EventEmitter)
  * @param {number} opts.rtcConfig                RTCPeerConnection configuration object
  * @param {number} opts.wrtc                     custom webrtc impl (useful in node.js)
  * @param {object} opts.httpAgent                HTTP agent impl (used to proxy http requests in node.js)
+ * @param {object} opts.socksProxyOpts           socks proxy options (used to proxy UDP requests in node.js)
  */
 function Client (opts) {
   var self = this
@@ -64,6 +65,7 @@ function Client (opts) {
   self._rtcConfig = opts.rtcConfig
   self._wrtc = opts.wrtc
   self._httpAgent = opts.httpAgent
+  self._socksProxyOpts = opts.socksProxyOpts
   self._getAnnounceOpts = opts.getAnnounceOpts
 
   debug('new client %s', self.infoHash)

--- a/client.js
+++ b/client.js
@@ -67,14 +67,6 @@ function Client (opts) {
   self._getAnnounceOpts = opts.getAnnounceOpts
   self._proxyOpts = opts.proxyOpts
 
-  // Create HTTP agents from socks proxy if needed
-  if (self._proxyOpts && self._proxyOpts.socksProxy && !self._proxyOpts.httpAgent) {
-    self._proxyOpts.httpAgent = new Socks.Agent(self._proxyOpts.socksProxy, false)
-  }
-  if (self._proxyOpts && self._proxyOpts.socksProxy && !self._proxyOpts.httpsAgent) {
-    self._proxyOpts.httpsAgent = new Socks.Agent(self._proxyOpts.socksProxy, true)
-  }
-
   debug('new client %s', self.infoHash)
 
   var webrtcSupport = self._wrtc !== false && (!!self._wrtc || Peer.WEBRTC_SUPPORT)

--- a/client.js
+++ b/client.js
@@ -31,6 +31,7 @@ inherits(Client, EventEmitter)
  * @param {function} opts.getAnnounceOpts        callback to provide data to tracker
  * @param {number} opts.rtcConfig                RTCPeerConnection configuration object
  * @param {number} opts.wrtc                     custom webrtc impl (useful in node.js)
+ * @param {object} opts.httpAgent                HTTP agent impl (used to proxy http requests in node.js)
  */
 function Client (opts) {
   var self = this
@@ -62,6 +63,7 @@ function Client (opts) {
 
   self._rtcConfig = opts.rtcConfig
   self._wrtc = opts.wrtc
+  self._httpAgent = opts.httpAgent
   self._getAnnounceOpts = opts.getAnnounceOpts
 
   debug('new client %s', self.infoHash)

--- a/lib/client/http-tracker.js
+++ b/lib/client/http-tracker.js
@@ -87,8 +87,10 @@ HTTPTracker.prototype.destroy = function (cb) {
 
 HTTPTracker.prototype._request = function (requestUrl, params, cb) {
   var self = this
-  var u = requestUrl + (requestUrl.indexOf('?') === -1 ? '?' : '&') +
-    common.querystringStringify(params)
+  var u = {
+    url: requestUrl + (requestUrl.indexOf('?') === -1 ? '?' : '&') + common.querystringStringify(params),
+    agent: self.client._httpAgent
+  }
 
   get.concat(u, function (err, res, data) {
     if (self.destroyed) return

--- a/lib/client/http-tracker.js
+++ b/lib/client/http-tracker.js
@@ -6,6 +6,7 @@ var debug = require('debug')('bittorrent-tracker:http-tracker')
 var extend = require('xtend')
 var get = require('simple-get')
 var inherits = require('inherits')
+var url = require('url')
 
 var common = require('../common')
 var Tracker = require('./tracker')
@@ -87,9 +88,15 @@ HTTPTracker.prototype.destroy = function (cb) {
 
 HTTPTracker.prototype._request = function (requestUrl, params, cb) {
   var self = this
+  var parsedUrl = url.parse(requestUrl + (requestUrl.indexOf('?') === -1 ? '?' : '&') + common.querystringStringify(params))
+  var agent
+  if (self.client._proxyOpts) {
+    agent = parsedUrl.protocol === 'https:'
+      ? self.client._proxyOpts.httpsAgent : self.client._proxyOpts.httpAgent
+  }
   var u = {
-    url: requestUrl + (requestUrl.indexOf('?') === -1 ? '?' : '&') + common.querystringStringify(params),
-    agent: self.client._httpAgent
+    url: parsedUrl,
+    agent: agent
   }
 
   get.concat(u, function (err, res, data) {

--- a/lib/client/http-tracker.js
+++ b/lib/client/http-tracker.js
@@ -2,6 +2,7 @@ module.exports = HTTPTracker
 
 var bencode = require('bencode')
 var compact2string = require('compact2string')
+var clone = require('clone')
 var debug = require('debug')('bittorrent-tracker:http-tracker')
 var extend = require('xtend')
 var get = require('simple-get')
@@ -95,7 +96,7 @@ HTTPTracker.prototype._request = function (requestUrl, params, cb) {
     agent = parsedUrl.protocol === 'https:'
       ? self.client._proxyOpts.httpsAgent : self.client._proxyOpts.httpAgent
     if (!agent && self.client._proxyOpts.socksProxy) {
-      agent = new Socks.Agent(extend(self.client._proxyOpts.socksProxy), (parsedUrl.protocol === 'https:'))
+      agent = new Socks.Agent(clone(self.client._proxyOpts.socksProxy), (parsedUrl.protocol === 'https:'))
     }
   }
   var u = {

--- a/lib/client/http-tracker.js
+++ b/lib/client/http-tracker.js
@@ -6,6 +6,7 @@ var debug = require('debug')('bittorrent-tracker:http-tracker')
 var extend = require('xtend')
 var get = require('simple-get')
 var inherits = require('inherits')
+var Socks = require('socks')
 var url = require('url')
 
 var common = require('../common')
@@ -93,6 +94,9 @@ HTTPTracker.prototype._request = function (requestUrl, params, cb) {
   if (self.client._proxyOpts) {
     agent = parsedUrl.protocol === 'https:'
       ? self.client._proxyOpts.httpsAgent : self.client._proxyOpts.httpAgent
+    if (!agent && self.client._proxyOpts.socksProxy) {
+      agent = new Socks.Agent(extend(self.client._proxyOpts.socksProxy), (parsedUrl.protocol === 'https:'))
+    }
   }
   var u = {
     url: parsedUrl,

--- a/lib/client/udp-tracker.js
+++ b/lib/client/udp-tracker.js
@@ -2,10 +2,10 @@ module.exports = UDPTracker
 
 var BN = require('bn.js')
 var Buffer = require('safe-buffer').Buffer
+var clone = require('clone')
 var compact2string = require('compact2string')
 var debug = require('debug')('bittorrent-tracker:udp-tracker')
 var dgram = require('dgram')
-var extend = require('xtend')
 var inherits = require('inherits')
 var randombytes = require('randombytes')
 var Socks = require('socks')
@@ -77,7 +77,7 @@ UDPTracker.prototype._request = function (opts) {
   var relay
   var transactionId = genTransactionId()
 
-  var proxyOpts = self.client._proxyOpts && extend(self.client._proxyOpts.socksProxy)
+  var proxyOpts = self.client._proxyOpts && clone(self.client._proxyOpts.socksProxy)
   if (proxyOpts) {
     if (!proxyOpts.proxy) {
       proxyOpts.proxy = {}

--- a/lib/client/udp-tracker.js
+++ b/lib/client/udp-tracker.js
@@ -7,6 +7,7 @@ var debug = require('debug')('bittorrent-tracker:udp-tracker')
 var dgram = require('dgram')
 var inherits = require('inherits')
 var randombytes = require('randombytes')
+var Socks = require('socks')
 var url = require('url')
 
 var common = require('../common')
@@ -63,8 +64,27 @@ UDPTracker.prototype._request = function (opts) {
   var self = this
   if (!opts) opts = {}
   var parsedUrl = url.parse(self.announceUrl)
+  if (!parsedUrl.port) {
+    parsedUrl.port = 80
+  }
+  var timeout
+  var socket
   var transactionId = genTransactionId()
-  var socket = dgram.createSocket('udp4')
+  if (self.client._socksProxyOpts) {
+    // UDP requests uses the associate command
+    self.client._socksProxyOpts.command = 'associate'
+    if (!self.client._socksProxyOpts.target) {
+      // This should contain client IP and port but can be set to 0 if we don't have this information
+      self.client._socksProxyOpts.target = {
+        host: '0.0.0.0',
+        port: 0
+      }
+    }
+
+    Socks.createConnection(self.client._socksProxyOpts, onGotSocket)
+  } else {
+    onGotSocket(null, dgram.createSocket('udp4'))
+  }
 
   var cleanup = function () {
     if (!socket) return
@@ -81,23 +101,29 @@ UDPTracker.prototype._request = function (opts) {
   }
   self.cleanupFns.push(cleanup)
 
-  // does not matter if `stopped` event arrives, so supress errors & cleanup after timeout
-  var ms = opts.event === 'stopped' ? TIMEOUT / 10 : TIMEOUT
-  var timeout = setTimeout(function () {
-    timeout = null
-    if (opts.event === 'stopped') cleanup()
-    else onError(new Error('tracker request timed out (' + opts.event + ')'))
-  }, ms)
-  if (timeout.unref) timeout.unref()
+  function onGotSocket (err, s, info) {
+    if (err) return onError(err)
 
-  send(Buffer.concat([
-    common.CONNECTION_ID,
-    common.toUInt32(common.ACTIONS.CONNECT),
-    transactionId
-  ]))
+    socket = s
 
-  socket.on('error', onError)
-  socket.on('message', onSocketMessage)
+    // does not matter if `stopped` event arrives, so supress errors & cleanup after timeout
+    var ms = opts.event === 'stopped' ? TIMEOUT / 10 : TIMEOUT
+    timeout = setTimeout(function () {
+      timeout = null
+      if (opts.event === 'stopped') cleanup()
+      else onError(new Error('tracker request timed out (' + opts.event + ')'))
+    }, ms)
+    if (timeout.unref) timeout.unref()
+
+    send(Buffer.concat([
+      common.CONNECTION_ID,
+      common.toUInt32(common.ACTIONS.CONNECT),
+      transactionId
+    ]), info)
+
+    socket.on('error', onError)
+    socket.on('message', onSocketMessage)
+  }
 
   function onSocketMessage (msg) {
     if (self.destroyed) return
@@ -180,11 +206,13 @@ UDPTracker.prototype._request = function (opts) {
     self.client.emit('warning', err)
   }
 
-  function send (message) {
-    if (!parsedUrl.port) {
-      parsedUrl.port = 80
+  function send (message, info) {
+    if (info) {
+      var pack = Socks.createUDPFrame({ host: parsedUrl.hostname, port: parsedUrl.port }, message)
+      socket.send(pack, 0, pack.length, info.port, info.host)
+    } else {
+      socket.send(message, 0, message.length, parsedUrl.port, parsedUrl.hostname)
     }
-    socket.send(message, 0, message.length, parsedUrl.port, parsedUrl.hostname)
   }
 
   function announce (connectionId, opts) {

--- a/lib/client/udp-tracker.js
+++ b/lib/client/udp-tracker.js
@@ -68,8 +68,11 @@ UDPTracker.prototype._request = function (opts) {
     parsedUrl.port = 80
   }
   var timeout
+  // Socket used to connect to the socks server to create a relay, null if socks is disabled
   var proxySocket
+  // Socket used to connect to the tracker or to the socks relay if socks is enabled
   var socket
+  // Contains the host/port of the socks relay
   var relay
   var transactionId = genTransactionId()
   if (self.client._socksProxyOpts) {
@@ -218,10 +221,10 @@ UDPTracker.prototype._request = function (opts) {
     self.client.emit('warning', err)
   }
 
-  function send (message, info) {
-    if (info) {
+  function send (message, proxyInfo) {
+    if (proxyInfo) {
       var pack = Socks.createUDPFrame({ host: parsedUrl.hostname, port: parsedUrl.port }, message)
-      socket.send(pack, 0, pack.length, info.port, info.host)
+      socket.send(pack, 0, pack.length, proxyInfo.port, proxyInfo.host)
     } else {
       socket.send(message, 0, message.length, parsedUrl.port, parsedUrl.hostname)
     }

--- a/lib/client/udp-tracker.js
+++ b/lib/client/udp-tracker.js
@@ -71,8 +71,11 @@ UDPTracker.prototype._request = function (opts) {
   var socket
   var transactionId = genTransactionId()
   if (self.client._socksProxyOpts) {
+    if (!self.client._socksProxyOpts.proxy) {
+      self.client._socksProxyOpts.proxy = {}
+    }
     // UDP requests uses the associate command
-    self.client._socksProxyOpts.command = 'associate'
+    self.client._socksProxyOpts.proxy.command = 'associate'
     if (!self.client._socksProxyOpts.target) {
       // This should contain client IP and port but can be set to 0 if we don't have this information
       self.client._socksProxyOpts.target = {

--- a/lib/client/udp-tracker.js
+++ b/lib/client/udp-tracker.js
@@ -75,21 +75,23 @@ UDPTracker.prototype._request = function (opts) {
   // Contains the host/port of the socks relay
   var relay
   var transactionId = genTransactionId()
-  if (self.client._socksProxyOpts) {
-    if (!self.client._socksProxyOpts.proxy) {
-      self.client._socksProxyOpts.proxy = {}
+
+  var proxyOpts = self.client._proxyOpts && self.client._proxyOpts.socksProxy
+  if (proxyOpts) {
+    if (!proxyOpts.proxy) {
+      proxyOpts.proxy = {}
     }
     // UDP requests uses the associate command
-    self.client._socksProxyOpts.proxy.command = 'associate'
-    if (!self.client._socksProxyOpts.target) {
+    proxyOpts.proxy.command = 'associate'
+    if (!proxyOpts.target) {
       // This should contain client IP and port but can be set to 0 if we don't have this information
-      self.client._socksProxyOpts.target = {
+      proxyOpts.target = {
         host: '0.0.0.0',
         port: 0
       }
     }
 
-    Socks.createConnection(self.client._socksProxyOpts, onGotConnection)
+    Socks.createConnection(proxyOpts, onGotConnection)
   } else {
     onGotConnection(null)
   }
@@ -141,7 +143,7 @@ UDPTracker.prototype._request = function (opts) {
 
   function onSocketMessage (msg) {
     if (self.destroyed) return
-    if (self.client._socksProxyOpts) msg = msg.slice(10)
+    if (proxySocket) msg = msg.slice(10)
     if (msg.length < 8 || msg.readUInt32BE(4) !== transactionId.readUInt32BE(0)) {
       return onError(new Error('tracker sent invalid transaction id'))
     }

--- a/lib/client/udp-tracker.js
+++ b/lib/client/udp-tracker.js
@@ -79,7 +79,6 @@ UDPTracker.prototype._request = function (opts) {
 
   var proxyOpts = self.client._proxyOpts && extend(self.client._proxyOpts.socksProxy)
   if (proxyOpts) {
-    proxyOpts.proxy = extend(proxyOpts.proxy)
     if (!proxyOpts.proxy) {
       proxyOpts.proxy = {}
     }

--- a/lib/client/udp-tracker.js
+++ b/lib/client/udp-tracker.js
@@ -5,6 +5,7 @@ var Buffer = require('safe-buffer').Buffer
 var compact2string = require('compact2string')
 var debug = require('debug')('bittorrent-tracker:udp-tracker')
 var dgram = require('dgram')
+var extend = require('xtend')
 var inherits = require('inherits')
 var randombytes = require('randombytes')
 var Socks = require('socks')
@@ -76,8 +77,9 @@ UDPTracker.prototype._request = function (opts) {
   var relay
   var transactionId = genTransactionId()
 
-  var proxyOpts = self.client._proxyOpts && self.client._proxyOpts.socksProxy
+  var proxyOpts = self.client._proxyOpts && extend(self.client._proxyOpts.socksProxy)
   if (proxyOpts) {
+    proxyOpts.proxy = extend(proxyOpts.proxy)
     if (!proxyOpts.proxy) {
       proxyOpts.proxy = {}
     }

--- a/lib/client/udp-tracker.js
+++ b/lib/client/udp-tracker.js
@@ -91,7 +91,12 @@ UDPTracker.prototype._request = function (opts) {
       }
     }
 
-    Socks.createConnection(proxyOpts, onGotConnection)
+    if (proxyOpts.proxy.type === 5) {
+      Socks.createConnection(proxyOpts, onGotConnection)
+    } else {
+      debug('Ignoring Socks proxy for UDP request because type 5 is required')
+      onGotConnection(null)
+    }
   } else {
     onGotConnection(null)
   }

--- a/lib/client/udp-tracker.js
+++ b/lib/client/udp-tracker.js
@@ -68,7 +68,9 @@ UDPTracker.prototype._request = function (opts) {
     parsedUrl.port = 80
   }
   var timeout
+  var proxySocket
   var socket
+  var relay
   var transactionId = genTransactionId()
   if (self.client._socksProxyOpts) {
     if (!self.client._socksProxyOpts.proxy) {
@@ -84,9 +86,9 @@ UDPTracker.prototype._request = function (opts) {
       }
     }
 
-    Socks.createConnection(self.client._socksProxyOpts, onGotSocket)
+    Socks.createConnection(self.client._socksProxyOpts, onGotConnection)
   } else {
-    onGotSocket(null, dgram.createSocket('udp4'))
+    onGotConnection(null)
   }
 
   var cleanup = function () {
@@ -101,13 +103,19 @@ UDPTracker.prototype._request = function (opts) {
     socket.on('error', noop) // ignore all future errors
     try { socket.close() } catch (err) {}
     socket = null
+    if (proxySocket) {
+      try { proxySocket.close() } catch (err) {}
+      proxySocket = null
+    }
   }
   self.cleanupFns.push(cleanup)
 
-  function onGotSocket (err, s, info) {
+  function onGotConnection (err, s, info) {
     if (err) return onError(err)
 
-    socket = s
+    proxySocket = s
+    socket = dgram.createSocket('udp4')
+    relay = info
 
     // does not matter if `stopped` event arrives, so supress errors & cleanup after timeout
     var ms = opts.event === 'stopped' ? TIMEOUT / 10 : TIMEOUT
@@ -122,7 +130,7 @@ UDPTracker.prototype._request = function (opts) {
       common.CONNECTION_ID,
       common.toUInt32(common.ACTIONS.CONNECT),
       transactionId
-    ]), info)
+    ]), relay)
 
     socket.on('error', onError)
     socket.on('message', onSocketMessage)
@@ -130,6 +138,7 @@ UDPTracker.prototype._request = function (opts) {
 
   function onSocketMessage (msg) {
     if (self.destroyed) return
+    if (self.client._socksProxyOpts) msg = msg.slice(10)
     if (msg.length < 8 || msg.readUInt32BE(4) !== transactionId.readUInt32BE(0)) {
       return onError(new Error('tracker sent invalid transaction id'))
     }
@@ -235,7 +244,7 @@ UDPTracker.prototype._request = function (opts) {
       common.toUInt32(0), // key (optional)
       common.toUInt32(opts.numwant),
       toUInt16(self.client._port)
-    ]))
+    ]), relay)
   }
 
   function scrape (connectionId) {
@@ -250,7 +259,7 @@ UDPTracker.prototype._request = function (opts) {
       common.toUInt32(common.ACTIONS.SCRAPE),
       transactionId,
       infoHash
-    ]))
+    ]), relay)
   }
 }
 

--- a/lib/client/websocket-tracker.js
+++ b/lib/client/websocket-tracker.js
@@ -1,5 +1,6 @@
 module.exports = WebSocketTracker
 
+var clone = require('clone')
 var debug = require('debug')('bittorrent-tracker:websocket-tracker')
 var extend = require('xtend')
 var inherits = require('inherits')
@@ -175,7 +176,7 @@ WebSocketTracker.prototype._openSocket = function () {
       agent = parsedUrl.protocol === 'wss:'
         ? self.client._proxyOpts.httpsAgent : self.client._proxyOpts.httpAgent
       if (!agent && self.client._proxyOpts.socksProxy) {
-        agent = new Socks.Agent(extend(self.client._proxyOpts.socksProxy), (parsedUrl.protocol === 'wss:'))
+        agent = new Socks.Agent(clone(self.client._proxyOpts.socksProxy), (parsedUrl.protocol === 'wss:'))
       }
     }
     self.socket = socketPool[self.announceUrl] = new Socket(self.announceUrl, { agent: agent })

--- a/lib/client/websocket-tracker.js
+++ b/lib/client/websocket-tracker.js
@@ -167,7 +167,7 @@ WebSocketTracker.prototype._openSocket = function () {
   if (self.socket) {
     socketPool[self.announceUrl].consumers += 1
   } else {
-    self.socket = socketPool[self.announceUrl] = new Socket(self.announceUrl)
+    self.socket = socketPool[self.announceUrl] = new Socket(self.announceUrl, { agent: self.client._httpAgent })
     self.socket.consumers = 1
     self.socket.on('connect', self._onSocketConnectBound)
   }

--- a/lib/client/websocket-tracker.js
+++ b/lib/client/websocket-tracker.js
@@ -6,6 +6,7 @@ var inherits = require('inherits')
 var Peer = require('simple-peer')
 var randombytes = require('randombytes')
 var Socket = require('simple-websocket')
+var url = require('url')
 
 var common = require('../common')
 var Tracker = require('./tracker')
@@ -167,7 +168,13 @@ WebSocketTracker.prototype._openSocket = function () {
   if (self.socket) {
     socketPool[self.announceUrl].consumers += 1
   } else {
-    self.socket = socketPool[self.announceUrl] = new Socket(self.announceUrl, { agent: self.client._httpAgent })
+    var parsedUrl = url.parse(self.announceUrl)
+    var agent
+    if (self.client._proxyOpts) {
+      agent = parsedUrl.protocol === 'wss:'
+        ? self.client._proxyOpts.httpsAgent : self.client._proxyOpts.httpAgent
+    }
+    self.socket = socketPool[self.announceUrl] = new Socket(self.announceUrl, { agent: agent })
     self.socket.consumers = 1
     self.socket.on('connect', self._onSocketConnectBound)
   }

--- a/lib/client/websocket-tracker.js
+++ b/lib/client/websocket-tracker.js
@@ -6,6 +6,7 @@ var inherits = require('inherits')
 var Peer = require('simple-peer')
 var randombytes = require('randombytes')
 var Socket = require('simple-websocket')
+var Socks = require('socks')
 var url = require('url')
 
 var common = require('../common')
@@ -173,6 +174,9 @@ WebSocketTracker.prototype._openSocket = function () {
     if (self.client._proxyOpts) {
       agent = parsedUrl.protocol === 'wss:'
         ? self.client._proxyOpts.httpsAgent : self.client._proxyOpts.httpAgent
+      if (!agent && self.client._proxyOpts.socksProxy) {
+        agent = new Socks.Agent(extend(self.client._proxyOpts.socksProxy), (parsedUrl.protocol === 'wss:'))
+      }
     }
     self.socket = socketPool[self.announceUrl] = new Socket(self.announceUrl, { agent: agent })
     self.socket.consumers = 1

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "./lib/common-node.js": false,
     "./lib/client/http-tracker.js": false,
     "./lib/client/udp-tracker.js": false,
-    "./server.js": false
+    "./server.js": false,
+    "socks": false
   },
   "bugs": {
     "url": "https://github.com/feross/bittorrent-tracker/issues"
@@ -38,6 +39,7 @@
     "simple-get": "^2.0.0",
     "simple-peer": "^6.0.0",
     "simple-websocket": "^4.0.0",
+    "socks": "^1.1.9",
     "string2compact": "^1.1.1",
     "uniq": "^1.0.1",
     "ws": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "bencode": "^0.10.0",
     "bittorrent-peerid": "^1.0.2",
     "bn.js": "^4.4.0",
+    "clone": "^1.0.2",
     "compact2string": "^1.2.0",
     "debug": "^2.0.0",
     "inherits": "^2.0.1",

--- a/test/client.js
+++ b/test/client.js
@@ -3,6 +3,7 @@ var Client = require('../')
 var common = require('./common')
 var fixtures = require('webtorrent-fixtures')
 var http = require('http')
+var net = require('net')
 var test = require('tape')
 
 var peerId1 = Buffer.from('01234567890123456789')
@@ -388,9 +389,9 @@ function testClientStartHttpAgent (t, serverType) {
   common.createServer(t, serverType, function (server, announceUrl) {
     var agent = new http.Agent()
     var agentUsed = false
-    agent.createSocket = function (req, options) {
+    agent.createConnection = function (opts, fn) {
       agentUsed = true
-      return http.Agent.prototype.createSocket.call(this, req, options)
+      return net.createConnection(opts, fn)
     }
     var client = new Client({
       infoHash: fixtures.leaves.parsedTorrent.infoHash,

--- a/test/client.js
+++ b/test/client.js
@@ -2,6 +2,7 @@ var Buffer = require('safe-buffer').Buffer
 var Client = require('../')
 var common = require('./common')
 var fixtures = require('webtorrent-fixtures')
+var http = require('http')
 var test = require('tape')
 
 var peerId1 = Buffer.from('01234567890123456789')
@@ -379,4 +380,55 @@ test('http: client announce with numwant', function (t) {
 
 test('udp: client announce with numwant', function (t) {
   testClientAnnounceWithNumWant(t, 'udp')
+})
+
+function testClientStartHttpAgent (t, serverType) {
+  t.plan(5)
+
+  common.createServer(t, serverType, function (server, announceUrl) {
+    var agent = new http.Agent()
+    var agentUsed = false
+    agent.createSocket = function (req, options) {
+      agentUsed = true
+      return http.Agent.prototype.createSocket.call(this, req, options)
+    }
+    var client = new Client({
+      infoHash: fixtures.leaves.parsedTorrent.infoHash,
+      announce: announceUrl,
+      peerId: peerId1,
+      port: port,
+      wrtc: {},
+      httpAgent: agent
+    })
+
+    if (serverType === 'ws') common.mockWebsocketTracker(client)
+    client.on('error', function (err) { t.error(err) })
+    client.on('warning', function (err) { t.error(err) })
+
+    client.once('update', function (data) {
+      t.equal(data.announce, announceUrl)
+      t.equal(typeof data.complete, 'number')
+      t.equal(typeof data.incomplete, 'number')
+
+      t.ok(agentUsed)
+
+      client.stop()
+
+      client.once('update', function () {
+        t.pass('got response to stop')
+        server.close()
+        client.destroy()
+      })
+    })
+
+    client.start()
+  })
+}
+
+test('http: client.start(httpAgent)', function (t) {
+  testClientStartHttpAgent(t, 'http')
+})
+
+test('ws: client.start(httpAgent)', function (t) {
+  testClientStartHttpAgent(t, 'ws')
 })

--- a/test/client.js
+++ b/test/client.js
@@ -399,7 +399,9 @@ function testClientStartHttpAgent (t, serverType) {
       peerId: peerId1,
       port: port,
       wrtc: {},
-      httpAgent: agent
+      proxyOpts: {
+        httpAgent: agent
+      }
     })
 
     if (serverType === 'ws') common.mockWebsocketTracker(client)


### PR DESCRIPTION
Looking at feross/webtorrent#807, I am trying to add proxy support to tracker clients.

For now, I am thinking about adding an [http agent](https://nodejs.org/api/http.html#http_class_http_agent) option to allow proxying HTTP and WebSocket request by using a Socks or a HTTP proxy agent.

For UDP, I am using the Socks module directly, @feross you suggested to use a socks instance to avoid adding a dependency but the module is not designed that way.

We could add a layer but this seemed a bit complicated for this feature...
I finally achieved to run a working socks proxy for UDP, so I could test all trackers successfully.

I believe it's ready to merge now, let me know what you think.
