### PR TITLE
Initial stab at solving #181 - see notes in PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ var optionalOpts = {
       uploaded: 0,
       downloaded: 0,
       left: 0,
+      ip: 'custom.ip.address.or.hostname',
       customParam: 'blah' // custom parameters supported
     }
   }
@@ -252,6 +253,7 @@ $ bittorrent-tracker --help
 
   Options:
     -p, --port [number]  change the port [default: 8000]
+        --trust-ip       trust 'ip' parameter in GET requests
         --trust-proxy    trust 'x-forwarded-for' header from reverse proxy
         --interval       client announce interval (ms) [default: 600000]
         --http           enable http server

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -16,6 +16,7 @@ var argv = minimist(process.argv.slice(2), {
     'http',
     'quiet',
     'silent',
+    'trust-ip',
     'trust-proxy',
     'udp',
     'version',
@@ -53,6 +54,7 @@ if (argv.help) {
         --http-hostname [string]  change the http server hostname [default: '::']
         --udp-hostname [string]   change the udp hostname [default: '0.0.0.0']
         --udp6-hostname [string]  change the udp6 hostname [default: '::']
+        --trust-ip                trust 'ip' parameter in GET requests
         --trust-proxy             trust 'x-forwarded-for' header from reverse proxy
         --interval                client announce interval (ms) [default: 600000]
         --http                    enable http server
@@ -82,6 +84,7 @@ var server = new Server({
   http: argv.http,
   interval: argv.interval,
   stats: argv.stats,
+  trustIp: argv['trust-ip'],
   trustProxy: argv['trust-proxy'],
   udp: argv.udp,
   ws: argv.ws

--- a/lib/server/parse-http.js
+++ b/lib/server/parse-http.js
@@ -31,9 +31,11 @@ function parseHttpRequest (req, opts) {
       common.MAX_ANNOUNCE_PEERS
     )
 
-    params.ip = opts.trustProxy
-      ? req.headers['x-forwarded-for'] || req.connection.remoteAddress
-      : req.connection.remoteAddress.replace(common.REMOVE_IPV4_MAPPED_IPV6_RE, '') // force ipv4
+    params.ip = opts.trustIp
+      ? params.ip || opts.trustProxy
+        ? req.headers['x-forwarded-for'] || req.connection.remoteAddress.replace(common.REMOVE_IPV4_MAPPED_IPV6_RE, '') // force IPv4
+        : req.connection.remoteAddress.replace(common.REMOVE_IPV4_MAPPED_IPV6_RE, '')
+      : req.connection.remoteAddress.replace(common.REMOVE_IPV4_MAPPED_IPV6_RE, '')
     params.addr = (common.IPV6_RE.test(params.ip) ? '[' + params.ip + ']' : params.ip) + ':' + params.port
 
     params.headers = req.headers

--- a/lib/server/parse-http.js
+++ b/lib/server/parse-http.js
@@ -31,11 +31,18 @@ function parseHttpRequest (req, opts) {
       common.MAX_ANNOUNCE_PEERS
     )
 
-    params.ip = opts.trustIp
-      ? params.ip || opts.trustProxy
-        ? req.headers['x-forwarded-for'] || req.connection.remoteAddress.replace(common.REMOVE_IPV4_MAPPED_IPV6_RE, '') // force IPv4
-        : req.connection.remoteAddress.replace(common.REMOVE_IPV4_MAPPED_IPV6_RE, '')
-      : req.connection.remoteAddress.replace(common.REMOVE_IPV4_MAPPED_IPV6_RE, '')
+    // If we're trusting IPs supplied in the GET parameters, simply use that if available
+    if (opts.trustIp && params.ip) {
+      // No operation needed
+    // Else, if we're trusting proxied headers, use that value if available,
+    } else if (opts.trustProxy && req.headers['x-forwarded-for']) {
+      params.ip = req.headers['x-forwarded-for']
+    // Otherwise, simply use the connection's remote host address.
+    } else {
+      params.ip = req.connection.remoteAddress
+        // Remove IPv4-Mapped address prefix from IPv6 address if present
+        .replace(common.REMOVE_IPV4_MAPPED_IPV6_RE, '')
+    }
     params.addr = (common.IPV6_RE.test(params.ip) ? '[' + params.ip + ']' : params.ip) + ':' + params.port
 
     params.headers = req.headers

--- a/server.js
+++ b/server.js
@@ -29,6 +29,7 @@ inherits(Server, EventEmitter)
  *
  * @param {Object}  opts            options object
  * @param {Number}  opts.interval   tell clients to announce on this interval (ms)
+ * @param {Number}  opts.trustIp    trust 'ip' parameter in GET requests
  * @param {Number}  opts.trustProxy trust 'x-forwarded-for' header from reverse proxy
  * @param {boolean} opts.http       start an http server? (default: true)
  * @param {boolean} opts.udp        start a udp server? (default: true)
@@ -49,6 +50,7 @@ function Server (opts) {
     : 10 * 60 * 1000 // 10 min
 
   self._trustProxy = !!opts.trustProxy
+  self._trustIp = !!opts.trustIp
   if (typeof opts.filter === 'function') self._filter = opts.filter
 
   self.peersCacheLength = opts.peersCacheLength
@@ -366,6 +368,7 @@ Server.prototype.onHttpRequest = function (req, res, opts) {
   var self = this
   if (!opts) opts = {}
   opts.trustProxy = opts.trustProxy || self._trustProxy
+  opts.trustIp = opts.trustIp || self._trustIp
 
   var params
   try {
@@ -445,6 +448,7 @@ Server.prototype.onWebSocketConnection = function (socket, opts) {
   var self = this
   if (!opts) opts = {}
   opts.trustProxy = opts.trustProxy || self._trustProxy
+  opts.trustIp = opts.trustIp || self._trustIp
 
   socket.peerId = null // as hex
   socket.infoHashes = [] // swarms that this socket is participating in

--- a/test/client.js
+++ b/test/client.js
@@ -255,7 +255,8 @@ function testClientGetAnnounceOpts (t, serverType) {
       port: port,
       getAnnounceOpts: function () {
         return {
-          testParam: 'this is a test'
+          testParam: 'this is a test',
+          ip: 'test.bittorrenttest.xyz'
         }
       },
       wrtc: {}


### PR DESCRIPTION
Okay, this is my first attempt at solving #181 - there is some discussion to be had.

The good news is that it seems no modifications are necessary for the client! `ip` can be supplied in `getAnnounceOpts` and the client will send it. Phew!

This PR contains modifications to the server to support this field successfully. It adds a new cmd option, `--trust-ip` to correspond to the already existing `--trust-proxy`.

The first question is: when should we force IPv4? See here: https://github.com/feross/bittorrent-tracker/blob/master/lib/server/parse-http.js#L36

Should we only force IPv4 if trust proxy is turned off? I don't understand the original reasoning, so it's hard to update it accordingly.

The second question is: What should we do about the compact format? I think that this is currently non-BEP compliant: https://github.com/feross/bittorrent-tracker/blob/master/server.js#L635 because of [BEP23](http://www.bittorrent.org/beps/bep_0023.html), which (I think) says we can represent non-IP (hostname) IPs as encoded strings in compact format, which this regular expression will currently filter out so these peers are never returned. So, we'll need a regular expression that will return ipv4s-or-valid-hostnames, but I'd like to defer to the wizards on that one.

Still, I think that this PR will work for supplied IPs that return properly when `compact=0`, and updates both the server and client documentation accordingly. We just need to discuss when to force IPv4 and how to return hostname peers in the compact format.