### PR TITLE
 Add the packaging metadata to build the bittorrent-tracker snap

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -13,6 +13,6 @@ grade: devel
 confinement: strict
 
 parts:
-  tracker:
+  bittorrent-tracker:
     source: .
     plugin: nodejs

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -10,7 +10,7 @@ apps:
     plugs: [network, network-bind]
 
 grade: devel
-confinement: devmode
+confinement: strict
 
 parts:
   tracker:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,18 @@
+name: bittorrent-tracker
+version: master
+summary: Simple, robust, BitTorrent tracker
+description: |
+  Node.js implementation of a BitTorrent tracker, client and server.
+
+apps:
+  bittorrent-tracker:
+    command: bittorrent-tracker
+    plugs: [network, network-bind]
+
+grade: devel
+confinement: devmode
+
+parts:
+  tracker:
+    source: .
+    plugin: nodejs

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: bittorrent-tracker
-version: master
+version: git
 summary: Simple, robust, BitTorrent tracker
 description: |
   Node.js implementation of a BitTorrent tracker, client and server.
@@ -16,3 +16,4 @@ parts:
   bittorrent-tracker:
     source: .
     plugin: nodejs
+    build-packages: [g++, make, python]


### PR DESCRIPTION
This is a package for the secure installation of apps that works in most Linux distributions.
Landing it upstream will enable builds for adventurous users.