### PR TITLE
Provide context data to getAnnounceOpts

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,10 @@ var requiredOpts = {
 }
 
 var optionalOpts = {
-  getAnnounceOpts: function () {
+  getAnnounceOpts: function (opts) {
     // Provide a callback that will be called whenever announce() is called
-    // internally (on timer), or by the user
+    // internally (on timer), or by the user.
+    // this refers to the tracker and opts to the current announce options.
     return {
       uploaded: 0,
       downloaded: 0,

--- a/client.js
+++ b/client.js
@@ -61,7 +61,7 @@ function Client (opts) {
   self.destroyed = false
 
   self._port = opts.port
-  self._getAnnounceOpts = opts.getAnnounceOpts
+  self._getAnnounceOpts = opts.getAnnounceOpts && opts.getAnnounceOpts.bind(self)
   self._rtcConfig = opts.rtcConfig
   self._userAgent = opts.userAgent
 
@@ -296,6 +296,6 @@ Client.prototype._defaultAnnounceOpts = function (opts) {
   if (opts.uploaded == null) opts.uploaded = 0
   if (opts.downloaded == null) opts.downloaded = 0
 
-  if (self._getAnnounceOpts) opts = extend(opts, self._getAnnounceOpts())
+  if (self._getAnnounceOpts) opts = extend(opts, self._getAnnounceOpts(opts))
   return opts
 }

--- a/test/client.js
+++ b/test/client.js
@@ -301,7 +301,7 @@ test('ws: client.announce() with params', function (t) {
 })
 
 function testClientGetAnnounceOpts (t, serverType) {
-  t.plan(5)
+  t.plan(7)
 
   common.createServer(t, serverType, function (server, announceUrl) {
     var client = new Client({
@@ -309,8 +309,10 @@ function testClientGetAnnounceOpts (t, serverType) {
       announce: announceUrl,
       peerId: peerId1,
       port: port,
-      getAnnounceOpts: function () {
+      getAnnounceOpts: function (opts) {
         return {
+          infoHash: this.infoHash,
+          optsDL: opts.downloaded,
           testParam: 'this is a test'
         }
       },
@@ -319,6 +321,8 @@ function testClientGetAnnounceOpts (t, serverType) {
 
     server.on('start', function (peer, params) {
       t.equal(params.testParam, 'this is a test')
+      t.equal(params.infoHash, fixtures.leaves.parsedTorrent.infoHash)
+      t.equal(params.optsDL, params.downloaded)
     })
 
     if (serverType === 'ws') common.mockWebsocketTracker(client)


### PR DESCRIPTION
I use `getAnnounceOpts` to extends announce with extra statistics but it is hard to manage multiple torrents without having any information about the torrent or the tracker involved.

This PR binds the tracker to `this` in `getAnnounceOpts` and adds the current opts in case we need it in the extensions.