### PR TITLE
Fix IPv6 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,9 @@ sudo: false
 node_js:
   - "node"
 before_script:
+  # Add an IPv6 config - see the corresponding Travis issue
+  # https://github.com/travis-ci/travis-ci/issues/8361
+  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+      sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6';
+    fi
   - export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start


### PR DESCRIPTION
Fix Travis tests by manually enabling IPv6.

This is a (temporal) solution posted by @bel2125 in [the issue #8361](https://github.com/travis-ci/travis-ci/issues/8361#issuecomment-350497804).