### PR TITLE
Expose WebSocketTracker socket pool

### DIFF
--- a/lib/client/websocket-tracker.js
+++ b/lib/client/websocket-tracker.js
@@ -14,6 +14,8 @@ var Tracker = require('./tracker')
 // In practice, WebSockets are pretty slow to establish, so this gives a nice performance
 // boost, and saves browser resources.
 var socketPool = {}
+// Normally this shouldn't be accessed but is occasionally useful
+WebSocketTracker._socketPool = socketPool
 
 var RECONNECT_MINIMUM = 15 * 1000
 var RECONNECT_MAXIMUM = 30 * 60 * 1000


### PR DESCRIPTION
This is necessary for the Internet Archive superpeer implementation.