### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ var requiredOpts = {
   infoHash: new Buffer('012345678901234567890'), // hex string or Buffer
   peerId: new Buffer('01234567890123456789'), // hex string or Buffer
   announce: [], // list of tracker server urls
-  port: 6881 // torrent client port, (in browser, optional)
+  port: 6881 // torrent client port (in browser)
 }
 
 var optionalOpts = {


### PR DESCRIPTION
In client.js the 'port' argument is mandatory rather than optional.

```
class Client extends EventEmitter {
   constructor (opts = {}) {
     super()
     [...]
     if (! process.browser &&! opts.port) throw new Error ('Option `port` is required')
```