### PR TITLE
Add "chromeapp" field to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
     "./lib/client/udp-tracker.js": false,
     "./server.js": false
   },
+  "chromeapp": {
+    "./server.js": false,
+    "dgram": "chrome-dgram"
+  },
   "bugs": {
     "url": "https://github.com/webtorrent/bittorrent-tracker/issues"
   },
@@ -23,6 +27,7 @@
     "bencode": "^2.0.0",
     "bittorrent-peerid": "^1.0.2",
     "bn.js": "^5.0.0",
+    "chrome-dgram": "^3.0.2",
     "compact2string": "^1.2.0",
     "debug": "^4.0.1",
     "ip": "^1.0.1",


### PR DESCRIPTION
I'm attempting to make a defacto standard for specifying Chrome App dependency substitutions using the `"chromeapp"` field in `package.json`.

The `"chromeapp"` field is just like the [`"browser"` field in `package.json`](https://github.com/defunctzombie/package-browser-field-spec) except it's intended for Chrome Apps instead of a generic browser environment. Bundler tools like `browserify` or `webpack` can be configured to look for the `"chromeapp"` field instead of the `"browser"` field when doing a build for a Chrome App.

In this specific package, since Chrome Apps can use raw sockets we want to replace e.g. `require('net')` with `require('chrome-net')`.