### PR TITLE
Check if socket is already connected in _openSocket().

### DIFF
--- a/lib/client/websocket-tracker.js
+++ b/lib/client/websocket-tracker.js
@@ -172,6 +172,9 @@ class WebSocketTracker extends Tracker {
     this.socket = socketPool[this.announceUrl]
     if (this.socket) {
       socketPool[this.announceUrl].consumers += 1
+      if (this.socket.connected) {
+        this._onSocketConnectBound()
+      }
     } else {
       this.socket = socketPool[this.announceUrl] = new Socket(this.announceUrl)
       this.socket.consumers = 1


### PR DESCRIPTION
Fixes https://github.com/webtorrent/webtorrent/issues/1245.

Calling `_onSocketConnectBound()` will set `this.reconnecting = false`, so the next time `announce()` is called, it won't exit early because it thinks the socket is still reconnecting.

Related: https://github.com/feross/simple-websocket/pull/56

There's a pattern in webtorrent + its child libs of not checking the connection state of connections it may not have initiated.