### PR TITLE
Error.message is read only on the QuickJS Runtime.

### DIFF
--- a/lib/client/udp-tracker.js
+++ b/lib/client/udp-tracker.js
@@ -130,7 +130,11 @@ class UDPTracker extends Tracker {
       cleanup()
       if (self.destroyed) return
 
-      if (err.message) err.message += ` (${self.announceUrl})`
+      try {
+        // Error.message is readonly on some platforms.
+        if (err.message) err.message += ` (${self.announceUrl})`
+      } catch (ignored) {
+      }
       // errors will often happen if a tracker is offline, so don't treat it as fatal
       self.client.emit('warning', err)
     }

--- a/lib/client/udp-tracker.js
+++ b/lib/client/udp-tracker.js
@@ -133,8 +133,7 @@ class UDPTracker extends Tracker {
       try {
         // Error.message is readonly on some platforms.
         if (err.message) err.message += ` (${self.announceUrl})`
-      } catch (ignored) {
-      }
+      } catch (ignoredErr) {}
       // errors will often happen if a tracker is offline, so don't treat it as fatal
       self.client.emit('warning', err)
     }


### PR DESCRIPTION
This causes another Error to be thrown.

<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Catch thrown Error.

**Which issue (if any) does this pull request address?**
Watch for thrown Error if Error.message is read only

**Is there anything you'd like reviewers to focus on?**
No

https://bellard.org/quickjs/