### PR TITLE
fix querystring tests

### DIFF
--- a/test/querystring.js
+++ b/test/querystring.js
@@ -3,9 +3,9 @@ var test = require('tape')
 
 // https://github.com/webtorrent/webtorrent/issues/196
 test('encode special chars +* in http tracker urls', function (t) {
-  var q = {
-    info_hash: Buffer.from('a2a15537542b22925ad10486bf7a8b2a9c42f0d1', 'hex').toString('binary')
-  }
+  var q = Object.create(null)
+  q.info_hash = Buffer.from('a2a15537542b22925ad10486bf7a8b2a9c42f0d1', 'hex').toString('binary')
+
   var encoded = 'info_hash=%A2%A1U7T%2B%22%92Z%D1%04%86%BFz%8B%2A%9CB%F0%D1'
   t.equal(common.querystringStringify(q), encoded)
 


### PR DESCRIPTION
The deep-equal check is in "strict mode" so it needs the prototypes of both objects to be equal. This fixes that.