### PR TITLE
fix: UDP url parsing

### DIFF
--- a/client.js
+++ b/client.js
@@ -86,7 +86,7 @@ class Client extends EventEmitter {
       .map(announceUrl => {
         let parsedUrl
         try {
-          parsedUrl = new URL(announceUrl)
+          parsedUrl = common.parseUrl(announceUrl)
         } catch (err) {
           nextTickWarn(new Error(`Invalid tracker URL: ${announceUrl}`))
           return null

--- a/lib/client/udp-tracker.js
+++ b/lib/client/udp-tracker.js
@@ -74,20 +74,7 @@ class UDPTracker extends Tracker {
     const self = this
     if (!opts) opts = {}
 
-    // HACK: Fix for WHATWG URL object not parsing non-standard URL schemes like
-    // 'udp:'. Just replace it with 'http:' since we only need the `hostname`
-    // and `port` properties.
-    //
-    // Note: Only affects Chrome and Firefox. Works fine in Node.js, Safari, and
-    // Edge.
-    //
-    // Note: UDP trackers aren't used in the normal browser build, but they are
-    // used in a Chrome App build (i.e. by Brave Browser).
-    //
-    // Bug reports:
-    // - Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=734880
-    // - Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1374505
-    let { hostname, port } = new URL(this.announceUrl.replace(/^udp:/, 'http:'))
+    let { hostname, port } = common.parseUrl(this.announceUrl)
     if (port === '') port = 80
 
     let transactionId = genTransactionId()

--- a/lib/common.js
+++ b/lib/common.js
@@ -32,22 +32,17 @@ exports.hexToBinary = function (str) {
 // - Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=734880
 // - Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1374505
 exports.parseUrl = function (str) {
-  const isUDP = str.match(/^udp:/)
-  const parsedUrl = (isUDP) ? new URL(str.replace(/^udp:/, 'http:')) : new URL(str)
+  const url = new URL(str.replace(/^udp:/, 'http:'))
 
-  return {
-    hash: parsedUrl.hash,
-    host: parsedUrl.host,
-    hostname: parsedUrl.hostname,
-    href: isUDP ? parsedUrl.href.replace(/^http:/, 'udp:') : parsedUrl.href,
-    origin: isUDP ? parsedUrl.origin.replace(/^http:/, 'udp:') : parsedUrl.origin,
-    password: parsedUrl.password,
-    pathname: parsedUrl.pathname,
-    port: parsedUrl.port,
-    protocol: isUDP ? 'udp:' : parsedUrl.protocol,
-    search: parsedUrl.search,
-    username: parsedUrl.username
+  if (str.match(/^udp:/)) {
+    Object.defineProperties(url, {
+      href: { value: url.href.replace(/^http/, 'udp') },
+      protocol: { value: url.protocol.replace(/^http/, 'udp') },
+      origin: { value: url.origin.replace(/^http/, 'udp') }
+    })
   }
+
+  return url
 }
 
 const config = require('./common-node')

--- a/lib/common.js
+++ b/lib/common.js
@@ -19,5 +19,36 @@ exports.hexToBinary = function (str) {
   return Buffer.from(str, 'hex').toString('binary')
 }
 
+// HACK: Fix for WHATWG URL object not parsing non-standard URL schemes like
+// 'udp:'. Just replace it with 'http:' since we only need a few properties.
+//
+// Note: Only affects Chrome and Firefox. Works fine in Node.js, Safari, and
+// Edge.
+//
+// Note: UDP trackers aren't used in the normal browser build, but they are
+// used in a Chrome App build (i.e. by Brave Browser).
+//
+// Bug reports:
+// - Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=734880
+// - Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1374505
+exports.parseUrl = function (str) {
+  const isUDP = str.match(/^udp:/)
+  const parsedUrl = (isUDP) ? new URL(str.replace(/^udp:/, 'http:')) : new URL(str)
+
+  return {
+    hash: parsedUrl.hash,
+    host: parsedUrl.host,
+    hostname: parsedUrl.hostname,
+    href: isUDP ? parsedUrl.href.replace(/^http:/, 'udp:') : parsedUrl.href,
+    origin: isUDP ? parsedUrl.origin.replace(/^http:/, 'udp:') : parsedUrl.origin,
+    password: parsedUrl.password,
+    pathname: parsedUrl.pathname,
+    port: parsedUrl.port,
+    protocol: isUDP ? 'udp:' : parsedUrl.protocol,
+    search: parsedUrl.search,
+    username: parsedUrl.username
+  }
+}
+
 const config = require('./common-node')
 Object.assign(exports, config)

--- a/test/client.js
+++ b/test/client.js
@@ -534,10 +534,34 @@ test('http: invalid tracker port', function (t) {
   testUnsupportedTracker(t, 'http://127.0.0.1:69691337/announce')
 })
 
+test('http: invalid tracker url', function (t) {
+  testUnsupportedTracker(t, 'http:')
+})
+
+test('http: invalid tracker url with slash', function (t) {
+  testUnsupportedTracker(t, 'http://')
+})
+
 test('udp: invalid tracker port', function (t) {
   testUnsupportedTracker(t, 'udp://127.0.0.1:69691337')
 })
 
+test('udp: invalid tracker url', function (t) {
+  testUnsupportedTracker(t, 'udp:')
+})
+
+test('udp: invalid tracker url with slash', function (t) {
+  testUnsupportedTracker(t, 'udp://')
+})
+
 test('ws: invalid tracker port', function (t) {
   testUnsupportedTracker(t, 'ws://127.0.0.1:69691337')
+})
+
+test('ws: invalid tracker url', function (t) {
+  testUnsupportedTracker(t, 'ws:')
+})
+
+test('ws: invalid tracker url with slash', function (t) {
+  testUnsupportedTracker(t, 'ws://')
 })


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
- As noted in the comments of the code, there is still a bug in Chrome and Firefox which doesn't correctly parse UDP urls.

- The previous code didn't handle the UDP case in the first parsing of the URL:

https://github.com/webtorrent/bittorrent-tracker/blob/2a12b752048d88452d91cd5fa4d8f03ac9131074/client.js#L89

- This PR creates a new function called `parseUrl` in the `common` file to handle the special case for UDP urls, so that the code can be reused wherever is necessary. 

**Which issue (if any) does this pull request address?**
Fixes webtorrent/webtorrent#2066

**Is there anything you'd like reviewers to focus on?**
Let me know if the implementation of `parseUrl` can be improved