### PR TITLE
Define DEFAULT_ANNOUNCE_INTERVAL (line 15)

### DIFF
--- a/lib/client/tracker.js
+++ b/lib/client/tracker.js
@@ -12,7 +12,7 @@ class Tracker extends EventEmitter {
   }
 
   setInterval (intervalMs) {
-    if (intervalMs == null) intervalMs = this.DEFAULT_ANNOUNCE_INTERVAL
+    if (intervalMs == null) intervalMs = this.DEFAULT_ANNOUNCE_INTERVAL // Define DEFAULT_ANNOUNCE_INTERVAL somewhere.
 
     clearInterval(this.interval)
 


### PR DESCRIPTION
Shouldn't DEFAULT_ANNOUNCE_INTERVAL be defined in the common.js file or in the constructor of Tracker? I can't find it anywhere in the other files as well. If this works some way that I can't see over here, I would be really grateful for a brief explanation.

<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
I just suggested a change to a potential bug.

**Which issue (if any) does this pull request address?**
An undefined attribute of the class Tracker.

**Is there anything you'd like reviewers to focus on?**
