### PR TITLE
fix: connection leaks

### DIFF
--- a/lib/client/websocket-tracker.js
+++ b/lib/client/websocket-tracker.js
@@ -301,6 +301,7 @@ class WebSocketTracker extends Tracker {
         clearTimeout(peer.trackerTimeout)
         peer.trackerTimeout = null
         delete this.peers[offerId]
+        peer.destroy()
       } else {
         debug(`got unexpected answer: ${JSON.stringify(data.answer)}`)
       }


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
clear up the peer resources when destroy

**Which issue (if any) does this pull request address?**
this PR *MAY* related to these issue: 
https://github.com/webtorrent/webtorrent/issues/1079
https://github.com/webtorrent/webtorrent-hybrid/issues/119


**Is there anything you'd like reviewers to focus on?**
There is another connection leak when tracker(WebRTC mode) interval is too small, for example 5 seconds, when webtorrent-hybrid as a seeder will announce too fast, and every time hybrid announce, It will create 5 offer peers here:
https://github.com/webtorrent/bittorrent-tracker/blob/master/lib/client/websocket-tracker.js#L63

and these peers only get destroy after 50 seconds:
https://github.com/webtorrent/bittorrent-tracker/blob/master/lib/client/websocket-tracker.js#L392

in this case, there will be more than 50 Peers, and make the hybrid hang forever (osx 12.2.1)