### PR TITLE
Let ws protcol in https context fail

### DIFF
--- a/client.js
+++ b/client.js
@@ -107,12 +107,6 @@ class Client extends EventEmitter {
         } else if (protocol === 'udp:' && typeof UDPTracker === 'function') {
           return new UDPTracker(this, announceUrl)
         } else if ((protocol === 'ws:' || protocol === 'wss:') && webrtcSupport) {
-          // Skip ws:// trackers on https:// sites because they throw SecurityError
-          if (protocol === 'ws:' && typeof window !== 'undefined' &&
-              window.location.protocol === 'https:') {
-            nextTickWarn(new Error(`Unsupported tracker protocol: ${announceUrl}`))
-            return null
-          }
           return new WebSocketTracker(this, announceUrl)
         } else {
           nextTickWarn(new Error(`Unsupported tracker protocol: ${announceUrl}`))


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

## What is the purpose of this pull request? (put an "X" next to item)

* [ ] Documentation update
* [X] Bug fix
* [ ] New feature
* [ ] Other, please explain:

## What changes did you make? (Give an overview)

Remove the check for `ws` protocol in `https` context in client (when mapping the announce URLs). The WebSocketTracker is then allays created.

## Which issue (if any) does this pull request address?

In secure context (HTTPS) the bittorrent-tracker client will not open any websocket if the announce URL is using `ws` protocol. This leads to **silent failing** in the announcing process. a `nextTickWarn` should give away the reason but if this is the only announce the tick will never happen.

Letting the websocket try to connect allows for nice an direct debug message:
```
simple-websocket [...] destroy (error: The operation is insecure.)
```
This error can be easily searched and traced back to Firefox's specific behavior on the matter.

## Is there anything you'd like reviewers to focus on?

We could have instead a debug message instead of removing the check. Both options looks better, in case of change of mind from Firefox in the future I think the WebSocket should be created anyway.
