### PR TITLE
adds handling for x-forwarded-for comma-separated syntax

### DIFF
--- a/lib/server/parse-http.js
+++ b/lib/server/parse-http.js
@@ -33,9 +33,17 @@ function parseHttpRequest (req, opts) {
       common.MAX_ANNOUNCE_PEERS
     )
 
-    params.ip = opts.trustProxy
-      ? req.headers['x-forwarded-for'] || req.connection.remoteAddress
-      : req.connection.remoteAddress.replace(common.REMOVE_IPV4_MAPPED_IPV6_RE, '') // force ipv4
+    if (opts.trustProxy) {
+      if (req.headers['x-forwarded-for']) {
+        const [realIp] = req.headers['x-forwarded-for'].split(',')
+        params.ip = realIp.trim()
+      } else {
+        params.ip = req.connection.remoteAddress
+      }
+    } else {
+      params.ip = req.connection.remoteAddress.replace(common.REMOVE_IPV4_MAPPED_IPV6_RE, '') // force ipv4
+    }
+
     params.addr = `${common.IPV6_RE.test(params.ip) ? `[${params.ip}]` : params.ip}:${params.port}`
 
     params.headers = req.headers

--- a/lib/server/parse-websocket.js
+++ b/lib/server/parse-websocket.js
@@ -55,9 +55,17 @@ function parseWebSocketRequest (socket, opts, params) {
   // On first parse, save important data from `socket.upgradeReq` and delete it
   // to reduce memory usage.
   if (socket.upgradeReq) {
-    socket.ip = opts.trustProxy
-      ? socket.upgradeReq.headers['x-forwarded-for'] || socket.upgradeReq.connection.remoteAddress
-      : socket.upgradeReq.connection.remoteAddress.replace(common.REMOVE_IPV4_MAPPED_IPV6_RE, '') // force ipv4
+    if (opts.trustProxy) {
+      if (socket.upgradeReq.headers['x-forwarded-for']) {
+        const [realIp] = socket.upgradeReq.headers['x-forwarded-for'].split(',')
+        socket.ip = realIp.trim()
+      } else {
+        socket.ip = socket.upgradeReq.connection.remoteAddress
+      }
+    } else {
+      socket.ip = socket.upgradeReq.connection.remoteAddress.replace(common.REMOVE_IPV4_MAPPED_IPV6_RE, '') // force ipv4
+    }
+
     socket.port = socket.upgradeReq.connection.remotePort
     if (socket.port) {
       socket.addr = `${common.IPV6_RE.test(socket.ip) ? `[${socket.ip}]` : socket.ip}:${socket.port}`


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Added better parsing of the `X-Forwarded-For` header when `trustProxy` is enabled.

The `X-Forwarded-For` header can contain a comma-separated list of IP addresses, the first being the client IP and the rest being the addresses of the proxies that the request passed through.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For#syntax

There was no handling for this in the server code, so if a list was passed in the header the IP regex test would fail and the peer doing the announce would not be added to the tracker.

This PR adds handling for when the header contains a comma-separated list, by splitting the header on `,` and setting the `ip` property to only the first value.

**Which issue (if any) does this pull request address?**

None

**Is there anything you'd like reviewers to focus on?**

I was unable to run the tests on an M1 macbook due to an arch error, so please check tests are passing.