### PR TITLE
perf: replace simple websocket with maintained one

### DIFF
--- a/lib/client/websocket-tracker.js
+++ b/lib/client/websocket-tracker.js
@@ -2,7 +2,7 @@ import clone from 'clone'
 import Debug from 'debug'
 import Peer from 'simple-peer'
 import randombytes from 'randombytes'
-import Socket from 'simple-websocket'
+import Socket from '@thaunknown/simple-websocket'
 import Socks from 'socks'
 
 import common from '../common.js'
@@ -214,7 +214,7 @@ class WebSocketTracker extends Tracker {
     this.expectingResponse = false
 
     try {
-      data = JSON.parse(data)
+      data = JSON.parse(Buffer.from(data))
     } catch (err) {
       this.client.emit('warning', new Error('Invalid tracker response'))
       return

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "type": "module",
   "dependencies": {
+    "@thaunknown/simple-websocket": "^9.1.0",
     "bencode": "^3.0.3",
     "bittorrent-peerid": "^1.3.3",
     "bn.js": "^5.2.0",
@@ -45,7 +46,6 @@
     "run-series": "^1.1.9",
     "simple-get": "^4.0.0",
     "simple-peer": "^9.11.0",
-    "simple-websocket": "^9.1.0",
     "socks": "^2.0.0",
     "string2compact": "^2.0.0",
     "unordered-array-remove": "^1.0.2",


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[ ] New feature
[x] Other, please explain:

**What changes did you make? (Give an overview)**
changed feross's simple-websocket to one maintained by me, since he stopped maintaining his for over a year now

this drops buffer and readable stream for streamx and uint8util from simple-websocket
