### PR TITLE
fix: mangled scrape infohashes

### DIFF
--- a/lib/client/http-tracker.js
+++ b/lib/client/http-tracker.js
@@ -4,7 +4,7 @@ import clone from 'clone'
 import Debug from 'debug'
 import get from 'simple-get'
 import Socks from 'socks'
-import { bin2hex, hex2bin, arr2text } from 'uint8-util'
+import { bin2hex, hex2bin, arr2text, text2arr, arr2hex } from 'uint8-util'
 
 import common from '../common.js'
 import Tracker from './tracker.js'
@@ -244,12 +244,14 @@ class HTTPTracker extends Tracker {
       return
     }
 
-    keys.forEach(infoHash => {
+    keys.forEach(_infoHash => {
       // TODO: optionally handle data.flags.min_request_interval
       // (separate from announce interval)
-      const response = Object.assign(data[infoHash], {
+      const infoHash = _infoHash.length !== 20 ? arr2hex(text2arr(_infoHash)) : bin2hex(_infoHash)
+
+      const response = Object.assign(data[_infoHash], {
         announce: this.announceUrl,
-        infoHash: bin2hex(infoHash)
+        infoHash
       })
       this.client.emit('scrape', response)
     })


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
scrape keys were mangled because of UTF8 conversion which cut it off, this was an issue in bencode which was patched, not fixed, this updates the code to support that patch