### PR TITLE
fix(parse-http): prevent announcement from peers with invalid ports

### DIFF
--- a/lib/server/parse-http.js
+++ b/lib/server/parse-http.js
@@ -22,7 +22,7 @@ export default function (req, opts) {
     params.peer_id = bin2hex(params.peer_id)
 
     params.port = Number(params.port)
-    if (!params.port) throw new Error('invalid port')
+    if (!params.port || params.port <= 0 || params.port > 65535) throw new Error('invalid port')
 
     params.left = Number(params.left)
     if (Number.isNaN(params.left)) params.left = Infinity


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

This change implements a small check within `parse-http.js` to prevent peers with invalid announcement ports from having their announcements accepted or added to the swarm. Valid ports within this implementation are considered any port within the range of 1 - 65535. 

**Note**: Port 0 is excluded as it is invalid for communication between hosts and is only used for local dynamic port binding.

**Which issue (if any) does this pull request address?**

#512 

**Is there anything you'd like reviewers to focus on?**
