### PR TITLE
Add event timestamp

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -86,22 +86,22 @@ const server = new Server({
 })
 
 server.on('error', err => {
-  if (!argv.silent) console.error(`ERROR: ${err.message}`)
+  if (!argv.silent) console.error(`${new Date().toISOString()} ERROR: ${err.message}`)
 })
 server.on('warning', err => {
-  if (!argv.quiet) console.log(`WARNING: ${err.message}`)
+  if (!argv.quiet) console.log(`${new Date().toISOString()} WARNING: ${err.message}`)
 })
 server.on('update', addr => {
-  if (!argv.quiet) console.log(`update: ${addr}`)
+  if (!argv.quiet) console.log(`${new Date().toISOString()} update: ${addr}`)
 })
 server.on('complete', addr => {
-  if (!argv.quiet) console.log(`complete: ${addr}`)
+  if (!argv.quiet) console.log(`${new Date().toISOString()} complete: ${addr}`)
 })
 server.on('start', addr => {
-  if (!argv.quiet) console.log(`start: ${addr}`)
+  if (!argv.quiet) console.log(`${new Date().toISOString()} start: ${addr}`)
 })
 server.on('stop', addr => {
-  if (!argv.quiet) console.log(`stop: ${addr}`)
+  if (!argv.quiet) console.log(`${new Date().toISOString()} stop: ${addr}`)
 })
 
 const hostname = {
@@ -115,30 +115,30 @@ server.listen(argv.port, hostname, () => {
     const httpAddr = server.http.address()
     const httpHost = httpAddr.address !== '::' ? httpAddr.address : 'localhost'
     const httpPort = httpAddr.port
-    console.log(`HTTP tracker: http://${httpHost}:${httpPort}/announce`)
+    console.log(`${new Date().toISOString()} HTTP tracker: http://${httpHost}:${httpPort}/announce`)
   }
   if (server.udp && !argv.quiet) {
     const udpAddr = server.udp.address()
     const udpHost = udpAddr.address
     const udpPort = udpAddr.port
-    console.log(`UDP tracker: udp://${udpHost}:${udpPort}`)
+    console.log(`${new Date().toISOString()} UDP tracker: udp://${udpHost}:${udpPort}`)
   }
   if (server.udp6 && !argv.quiet) {
     const udp6Addr = server.udp6.address()
     const udp6Host = udp6Addr.address !== '::' ? udp6Addr.address : 'localhost'
     const udp6Port = udp6Addr.port
-    console.log(`UDP6 tracker: udp://${udp6Host}:${udp6Port}`)
+    console.log(`${new Date().toISOString()} UDP6 tracker: udp://${udp6Host}:${udp6Port}`)
   }
   if (server.ws && !argv.quiet) {
     const wsAddr = server.http.address()
     const wsHost = wsAddr.address !== '::' ? wsAddr.address : 'localhost'
     const wsPort = wsAddr.port
-    console.log(`WebSocket tracker: ws://${wsHost}:${wsPort}`)
+    console.log(`${new Date().toISOString()} WebSocket tracker: ws://${wsHost}:${wsPort}`)
   }
   if (server.http && argv.stats && !argv.quiet) {
     const statsAddr = server.http.address()
     const statsHost = statsAddr.address !== '::' ? statsAddr.address : 'localhost'
     const statsPort = statsAddr.port
-    console.log(`Tracker stats: http://${statsHost}:${statsPort}/stats`)
+    console.log(`${new Date().toISOString()} Tracker stats: http://${statsHost}:${statsPort}/stats`)
   }
 })


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[x ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)** Added timestamps to the event logs

**Which issue (if any) does this pull request address?** It helps to correlate events that occur with your bittorrent client's logs.

**Is there anything you'd like reviewers to focus on?** No.

**New tracker log:**
```
2024-04-01T21:02:04.570Z bittorrent-tracker:server new server {"http":true,"stats":true,"trustProxy":false,"udp":true,"ws":true}
2024-04-01T21:02:04.670Z bittorrent-tracker:server listen (port: 8000 hostname: { http: undefined, udp4: undefined, udp6: undefined })
2024-04-01T21:02:04.889Z bittorrent-tracker:server listening
2024-04-01T21:02:04.890Z HTTP tracker: http://localhost:8000/announce
2024-04-01T21:02:04.904Z UDP tracker: udp://0.0.0.0:8000
2024-04-01T21:02:04.904Z UDP6 tracker: udp://localhost:8000
2024-04-01T21:02:04.904Z WebSocket tracker: ws://localhost:8000/
2024-04-01T21:02:04.904Z Tracker stats: http://localhost:8000/stats
2024-04-01T21:02:12.162Z start: 172.29.0.7:6881
2024-04-01T21:04:39.877Z start: 172.29.0.13:51414

```