### PR TITLE
Add subpath import for client and server

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ To start a BitTorrent tracker server to track swarms of peers:
 
 ```js
 import { Server } from 'bittorrent-tracker'
+// Or import Server from 'bittorrent-tracker/server'
 
 const server = new Server({
   udp: true, // enable udp server? [default=true]
@@ -267,6 +268,8 @@ Scraping multiple torrent info is possible with a static `Client.scrape` method:
 
 ```js
 import Client from 'bittorrent-tracker'
+// Or import Client from 'bittorrent-tracker/client'
+
 Client.scrape({ announce: announceUrl, infoHash: [ infoHash1, infoHash2 ]}, function (err, results) {
   results[infoHash1].announce
   results[infoHash1].infoHash

--- a/package.json
+++ b/package.json
@@ -64,7 +64,15 @@
     "node": ">=16.0.0"
   },
   "exports": {
-    "import": "./index.js"
+    ".": {
+      "import": "./index.js"
+    },
+    "./client": {
+      "import": "./client.js"
+    },
+    "./server": {
+      "import": "./server.js"
+    }
   },
   "keywords": [
     "bittorrent",


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

Allows to `import Server from "bittorrent-tracker/server` or `import Client from "bittorrent-tracker/client`

This can help front-end consumers that only use the client to not have to polyfill server dependencies for example.

[ ] Documentation update
[ ] Bug fix
[x] New feature
[ ] Other, please explain:
