### PR TITLE
fix: Revert "Bugfix - when using AbortController, errors on resulting stream must be caught"

### DIFF
--- a/lib/client/http-tracker.js
+++ b/lib/client/http-tracker.js
@@ -150,7 +150,6 @@ class HTTPTracker extends Tracker {
           'user-agent': this.client._userAgent || ''
         }
       })
-      if (res.body.on) res.body.on('error', cb)
     } catch (err) {
       if (err) return cb(err)
     }


### PR DESCRIPTION
Reverts webtorrent/bittorrent-tracker#539