### PR TITLE
fix: http announce no left

### DIFF
--- a/lib/client/http-tracker.js
+++ b/lib/client/http-tracker.js
@@ -56,7 +56,7 @@ class HTTPTracker extends Tracker {
       port: this.client._port
     })
 
-    if (params.left == null) params.left = 16384
+    if (params.left !== 0 && !params.left) params.left = 16384
     if (this._trackerId) params.trackerid = this._trackerId
 
     this._request(this.announceUrl, params, (err, data) => {

--- a/lib/client/http-tracker.js
+++ b/lib/client/http-tracker.js
@@ -55,6 +55,8 @@ class HTTPTracker extends Tracker {
       peer_id: this.client._peerIdBinary,
       port: this.client._port
     })
+
+    if (params.left == null) params.left = 16384
     if (this._trackerId) params.trackerid = this._trackerId
 
     this._request(this.announceUrl, params, (err, data) => {


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
for http announce, forced left to be a defined value, while the spec doesn't say what happens when left is null, most trackers error, libtorrent simply sets it to 16k in those cases so let's follow suit
**Which issue (if any) does this pull request address?**
webtorrent hanging on *some* magnet links as it announced left undefined, which queried the tracker with `&left&`
**Is there anything you'd like reviewers to focus on?**
