### PR TITLE
fix: move static function from ip to the parse-udp module

### DIFF
--- a/lib/server/parse-udp.js
+++ b/lib/server/parse-udp.js
@@ -1,6 +1,29 @@
-import ipLib from 'ip'
 import common from '../common.js'
 import { equal } from 'uint8-util'
+
+function ipToString (buff, offset, length) {
+  offset = ~~offset
+  length = length || (buff.length - offset)
+
+  let result = []
+  if (length === 4) {
+    // IPv4
+    for (let i = 0; i < length; i++) {
+      result.push(buff[offset + i])
+    }
+    result = result.join('.')
+  } else if (length === 16) {
+    // IPv6
+    for (let i = 0; i < length; i += 2) {
+      result.push(buff.readUInt16BE(offset + i).toString(16))
+    }
+    result = result.join(':')
+    result = result.replace(/(^|:)0(:0)*:0(:|$)/, '$1::$3')
+    result = result.replace(/:{3,4}/, '::')
+  }
+
+  return result
+};
 
 export default function (msg, rinfo) {
   if (msg.length < 16) throw new Error('received packet is too short')
@@ -30,7 +53,7 @@ export default function (msg, rinfo) {
 
     const ip = msg.readUInt32BE(84) // optional
     params.ip = ip
-      ? ipLib.toString(ip)
+      ? ipToString(ip)
       : rinfo.address
 
     params.key = msg.readUInt32BE(88) // Optional: unique random key from client

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "compact2string": "^1.4.1",
     "cross-fetch-ponyfill": "^1.0.3",
     "debug": "^4.3.4",
-    "ip": "^2.0.1",
     "lru": "^3.1.0",
     "minimist": "^1.2.8",
     "once": "^1.4.0",


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update  
[ ] Bug fix  
[ ] New feature  
[X] Other, please explain:  

For the past year, there has been a vulnerability in the less/not maintained `node-ip` package. While the vulnerability doesn't affect `bittorrent-tracker` directly, it still results in a `1 high severity vulnerability` warning after running `npm i` on this project or any other project that has `bittorrent-tracker` as a dependency. This creates a negative impression from a customer perspective or during code audits.

**What changes did you make? (Give an overview)**

This repository only uses a single static function from the `node-ip` package, which is unmaintained but available under the MIT license. I copied this static function directly into the `parse-udp` module and removed the `node-ip` dependency entirely.

I ran the tests, which show:

```zsh
1..557
# tests 557
# pass  557

# ok
````

Additionally, `npm i` now shows `found 0 vulnerabilities` after running the command.