### PR TITLE
Add http tracker announce url to warning messages.

### DIFF
--- a/lib/client/http-tracker.js
+++ b/lib/client/http-tracker.js
@@ -60,7 +60,7 @@ class HTTPTracker extends Tracker {
     if (this._trackerId) params.trackerid = this._trackerId
 
     this._request(this.announceUrl, params, (err, data) => {
-      if (err) return this.client.emit('warning', err)
+      if (err) return this.onError(err)
       this._onAnnounceResponse(data)
     })
   }
@@ -80,7 +80,7 @@ class HTTPTracker extends Tracker {
       info_hash: infoHashes
     }
     this._request(this.scrapeUrl, params, (err, data) => {
-      if (err) return this.client.emit('warning', err)
+      if (err) return this.onError(err)
       this._onScrapeResponse(data)
     })
   }
@@ -118,6 +118,16 @@ class HTTPTracker extends Tracker {
       self.cleanupFns = []
       cb(null)
     }
+  }
+
+  onError (err) {
+    try {
+      // Error.message is readonly on some platforms.
+      if (err.message) err.message += ` (${this.announceUrl})`
+    } catch (ignoredErr) {}
+    // errors will often happen if a tracker is offline, so don't treat it as fatal
+
+    this.client.emit('warning', err)
   }
 
   async _request (requestUrl, params, cb) {
@@ -164,7 +174,7 @@ class HTTPTracker extends Tracker {
       return cb(new Error(`Non-200 response code ${res.status} from ${this.announceUrl}`))
     }
     if (!data || data.length === 0) {
-      return cb(new Error(`Invalid tracker response from${this.announceUrl}`))
+      return cb(new Error(`Invalid tracker response from ${this.announceUrl}`))
     }
 
     try {
@@ -181,7 +191,7 @@ class HTTPTracker extends Tracker {
     const warning = data['warning message'] && arr2text(data['warning message'])
     if (warning) {
       debug(`warning from ${requestUrl} (${warning})`)
-      this.client.emit('warning', new Error(warning))
+      this.onError(new Error(warning))
     }
 
     debug(`response from ${requestUrl}`)
@@ -211,7 +221,7 @@ class HTTPTracker extends Tracker {
       try {
         addrs = compact2string.multi(Buffer.from(data.peers))
       } catch (err) {
-        return this.client.emit('warning', err)
+        return this.onError(err)
       }
       addrs.forEach(addr => {
         this.client.emit('peer', addr)
@@ -228,7 +238,7 @@ class HTTPTracker extends Tracker {
       try {
         addrs = compact2string.multi6(Buffer.from(data.peers6))
       } catch (err) {
-        return this.client.emit('warning', err)
+        return this.onError(err)
       }
       addrs.forEach(addr => {
         this.client.emit('peer', addr)
@@ -251,7 +261,7 @@ class HTTPTracker extends Tracker {
 
     const keys = Object.keys(data)
     if (keys.length === 0) {
-      this.client.emit('warning', new Error('invalid scrape response'))
+      this.onError(new Error('invalid scrape response'))
       return
     }
 


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[ ] New feature
[X] Other, please explain: Warning message improvement

**What changes did you make? (Give an overview)**
Add http tracker announce url to warning messages. This change is modeled on the way that the UDP tracker does warning messages. Also, add missing space to one of the error messages.