### PR TITLE
feat!: require Node.js 18 and use Undici 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ const optionalOpts = {
   proxyOpts: {
       // For WSS trackers this is always a http.Agent
       // For UDP trackers this is an object of options for the Socks Connection
-      // For HTTP trackers this is an undici Dispatcher, such as undici.Agent, ex:
+      // For HTTP trackers this is an undici Agent, ex:
       // import Socks from 'socks'
       // proxyOpts.socksProxy = new Socks.Agent(optionsObject, isHttps)
       // or

--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ const optionalOpts = {
   proxyOpts: {
       // For WSS trackers this is always a http.Agent
       // For UDP trackers this is an object of options for the Socks Connection
-      // For HTTP trackers this is either an undici Agent if using Node16 or later, or http.Agent if using versions prior to Node 16, ex:
+      // For HTTP trackers this is an undici Dispatcher, such as undici.Agent, ex:
       // import Socks from 'socks'
       // proxyOpts.socksProxy = new Socks.Agent(optionsObject, isHttps)
-      // or if using Node 16 or later
+      // or
       // import { socksDispatcher } from 'fetch-socks'
       // proxyOpts.socksProxy = socksDispatcher(optionsObject)
       socksProxy: new SocksProxy(socksOptionsObject),

--- a/lib/client/http-tracker.js
+++ b/lib/client/http-tracker.js
@@ -130,19 +130,24 @@ class HTTPTracker extends Tracker {
       }
     }
 
+    let controller = abortTimeout(common.REQUEST_TIMEOUT)
     const cleanup = () => {
-      if (!controller.signal.aborted) {
-        arrayRemove(this.cleanupFns, this.cleanupFns.indexOf(cleanup))
-        controller.abort()
-        controller = null
-      }
+      if (!controller) return
+
+      const cleanupIndex = this.cleanupFns.indexOf(cleanup)
+      if (cleanupIndex !== -1) arrayRemove(this.cleanupFns, cleanupIndex)
+
+      const requestController = controller
+      controller = null
+      if (!requestController.signal.aborted) requestController.abort()
+
       if (this.maybeDestroyCleanup) this.maybeDestroyCleanup()
     }
 
     this.cleanupFns.push(cleanup)
 
     let res
-    let controller = abortTimeout(common.REQUEST_TIMEOUT)
+    let data
     try {
       res = await fetch(parsedUrl.toString(), {
         agent,
@@ -152,13 +157,12 @@ class HTTPTracker extends Tracker {
           'user-agent': this.client._userAgent || ''
         }
       })
-      if (res.body.on) res.body.on('error', cb)
+      data = new Uint8Array(await res.arrayBuffer())
     } catch (err) {
-      cleanup()
       return cb(err)
+    } finally {
+      cleanup()
     }
-    let data = new Uint8Array(await res.arrayBuffer())
-    cleanup()
     if (this.destroyed) return
 
     if (res.status !== 200) {

--- a/lib/client/http-tracker.js
+++ b/lib/client/http-tracker.js
@@ -1,7 +1,7 @@
 import arrayRemove from 'unordered-array-remove'
 import bencode from 'bencode'
 import Debug from 'debug'
-import fetch from 'cross-fetch-ponyfill'
+import { fetch } from 'undici'
 import { bin2hex, hex2bin, arr2text, text2arr, arr2hex } from 'uint8-util'
 
 import common from '../common.js'
@@ -154,7 +154,8 @@ class HTTPTracker extends Tracker {
       })
       if (res.body.on) res.body.on('error', cb)
     } catch (err) {
-      if (err) return cb(err)
+      cleanup()
+      return cb(err)
     }
     let data = new Uint8Array(await res.arrayBuffer())
     cleanup()

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "bittorrent-peerid": "^2.0.0",
     "chrome-dgram": "^3.0.6",
     "compact2string": "^1.4.1",
-    "cross-fetch-ponyfill": "^1.0.3",
     "debug": "^4.3.4",
     "ip": "^2.0.1",
     "lru": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "socks": "^2.8.3",
     "string2compact": "^2.0.1",
     "uint8-util": "^2.2.5",
+    "undici": "^5.29.0",
     "unordered-array-remove": "^1.0.2",
     "ws": "^8.17.0"
   },
@@ -56,7 +57,6 @@
     "semantic-release": "25.0.9",
     "standard": "*",
     "tape": "5.10.2",
-    "undici": "^6.16.1",
     "webrtc-polyfill": "^1.1.5",
     "webtorrent-fixtures": "2.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "socks": "^2.8.3",
     "string2compact": "^2.0.1",
     "uint8-util": "^2.2.5",
-    "undici": "^5.29.0",
+    "undici": "^6.28.1",
     "unordered-array-remove": "^1.0.2",
     "ws": "^8.17.0"
   },
@@ -60,7 +60,7 @@
     "webtorrent-fixtures": "2.0.3"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.17.0"
   },
   "exports": {
     ".": {

--- a/test/client.js
+++ b/test/client.js
@@ -674,3 +674,36 @@ test('http: failed httpAgent request is cleaned up', function (t) {
     client.start()
   })
 })
+
+test('http: failed response body is cleaned up', function (t) {
+  t.plan(3)
+
+  const server = http.createServer((req, res) => {
+    res.writeHead(200, { 'content-length': 100 })
+    res.flushHeaders()
+    res.write('incomplete')
+    setImmediate(() => res.destroy())
+  })
+  server.on('error', err => { t.error(err) })
+  server.listen(0, '127.0.0.1', () => {
+    const client = new Client({
+      infoHash: fixtures.leaves.parsedTorrent.infoHash,
+      announce: `http://127.0.0.1:${server.address().port}/announce`,
+      peerId: peerId1,
+      port,
+      wrtc: {}
+    })
+
+    client.once('error', err => { t.error(err) })
+    client.once('warning', err => {
+      t.ok(err, 'got response body error')
+      client.destroy(err => {
+        t.error(err)
+        t.pass('client destroyed after response body error')
+        server.close()
+      })
+    })
+
+    client.start()
+  })
+})

--- a/test/client.js
+++ b/test/client.js
@@ -398,7 +398,7 @@ function testClientAnnounceWithNumWant (t, serverType) {
         client3.on('warning', err => { t.error(err) })
 
         client3.start({ numwant: 1 })
-        client3.on('peer', () => {
+        client3.once('peer', () => {
           t.pass('got one peer (this should only fire once)')
 
           let num = 3
@@ -637,4 +637,40 @@ test('http: client.start(httpAgent)', function (t) {
 
 test('ws: client.start(httpAgent)', function (t) {
   testClientStartHttpAgent(t, 'ws')
+})
+
+test('http: failed httpAgent request is cleaned up', function (t) {
+  t.plan(4)
+
+  common.createServer(t, 'http', function (server, announceUrl) {
+    const agent = new undici.Agent({
+      connect (opts, cb) {
+        t.pass('custom agent used')
+        process.nextTick(cb, new Error('expected connect failure'), null)
+      }
+    })
+    const client = new Client({
+      infoHash: fixtures.leaves.parsedTorrent.infoHash,
+      announce: announceUrl,
+      peerId: peerId1,
+      port,
+      wrtc: {},
+      proxyOpts: {
+        httpAgent: agent
+      }
+    })
+
+    client.once('error', err => { t.error(err) })
+    client.once('warning', err => {
+      t.equal(err.cause.message, 'expected connect failure')
+      client.destroy(err => {
+        t.error(err)
+        t.pass('client destroyed after failed request')
+        server.close()
+        agent.close()
+      })
+    })
+
+    client.start()
+  })
 })

--- a/test/scrape.js
+++ b/test/scrape.js
@@ -3,8 +3,8 @@ import Client from '../index.js'
 import common from './common.js'
 import commonLib from '../lib/common.js'
 import fixtures from 'webtorrent-fixtures'
-import fetch from 'cross-fetch-ponyfill'
 import test from 'tape'
+import { fetch } from 'undici'
 import { hex2bin } from 'uint8-util'
 
 const peerId = Buffer.from('01234567890123456789')

--- a/test/stats.js
+++ b/test/stats.js
@@ -1,8 +1,8 @@
 import Client from '../index.js'
 import commonTest from './common.js'
 import fixtures from 'webtorrent-fixtures'
-import fetch from 'cross-fetch-ponyfill'
 import test from 'tape'
+import { fetch } from 'undici'
 
 const peerId = Buffer.from('-WW0091-4ea5886ce160')
 const unknownPeerId = Buffer.from('01234567890123456789')


### PR DESCRIPTION
## Summary

- require Node.js 18.17 or newer and move to Undici 6
- use one consistent Undici implementation for HTTP tracker requests and custom dispatchers
- remove `cross-fetch-ponyfill`; tests and runtime requests now share Undici
- clean up pending requests when fetch fails
- prevent repeated teardown in the `numwant: 1` test
- add a regression test for cleanup after connector failure

## Breaking change

Node.js 16 is no longer supported. The new minimum is Node.js 18.17.0, matching Undici 6 requirements. CI remains on Node 18.

## Browser compatibility

The HTTP tracker module is mapped to `false` by the package `browser` field, so the Node-only Undici dependency is excluded from browser bundles that honor that mapping.

## Testing

- `XDG_CACHE_HOME=/tmp/webtorrent-bittorrent-tracker-cache npm test`
- 564 tests passed, 0 failed on Node 26.8.1

The local `LOW_HANGING_FRUIT.md` audit file is intentionally excluded.